### PR TITLE
Added nicer cache info output.

### DIFF
--- a/shell/cache.php
+++ b/shell/cache.php
@@ -101,6 +101,14 @@ class Guidance_Shell_Cache extends Mage_Shell_Abstract
      */
     public function info() {
         $invalidTypes = $this->_getInvalidatedTypes();
+        $line = '--------------------------+--------------+-----------+-------------------------------+' . "\n";
+        echo $line;
+        echo sprintf(' %-25s|','Cache ID');
+        echo sprintf(' %-13s|','Cache Status');
+        echo sprintf(' %-10s|','Validity');
+        echo sprintf(' %-30s|','Cache Type');
+        echo "\n";
+        echo $line;
         foreach($this->_getCacheTypes() as $cache) {
             $enabled = ($cache->status)? 'Enabled':'Disabled';
             if($enabled=='Enabled') {
@@ -109,11 +117,13 @@ class Guidance_Shell_Cache extends Mage_Shell_Abstract
                 $invalid = 'N/A';
             }
 
-            echo sprintf('%-16s', $cache->id);
-            echo sprintf('%-12s', $enabled);
-            echo sprintf('%-10s', $invalid);
-            echo  $cache->cache_type . "\n";
+            echo sprintf(' %-25s|', $cache->id);
+            echo sprintf(' %-13s|', $enabled);
+            echo sprintf(' %-10s|', $invalid);
+            echo sprintf(' %-30s|', $cache->cache_type);
+            echo  "\n";
         }
+        echo $line;
     }
 
     /**


### PR DESCRIPTION
This change adding nothing new. It's only about more user friendly output of `info` option. _( more table like )_

New output look like : 

```
--------------------------+--------------+-----------+-------------------------------+
 Cache ID                 | Cache Status | Validity  | Cache Type                    |
--------------------------+--------------+-----------+-------------------------------+
 config                   | Disabled     | N/A       | Configuration                 |
 layout                   | Disabled     | N/A       | Layouts                       |
 block_html               | Disabled     | N/A       | Blocks HTML output            |
 translate                | Disabled     | N/A       | Translations                  |
 collections              | Disabled     | N/A       | Collections Data              |
 eav                      | Disabled     | N/A       | EAV types and attributes      |
 config_api               | Disabled     | N/A       | Web Services Configuration    |
 config_api2              | Disabled     | N/A       | Web Services Configuration    |
--------------------------+--------------+-----------+-------------------------------+
```
